### PR TITLE
Fix webpack-devserver error

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint .",
     "build": "webpack --config webpack.prod.js",
-    "watch": "webpack --config webpack.dev.js --watch -d"
+    "watch": "webpack --config webpack.dev.js --watch"
   },
   "repository": {
     "type": "git",

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -2,5 +2,6 @@ const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
-  mode: 'development'
+  mode: 'development',
+  devtool: 'source-map'
 });


### PR DESCRIPTION
```
localhost: query_ok$ be middleman
== The Middleman is loading
== Executing: `npm run watch`
== Blog Sources: posts/{year}-{month}-{day}-{title}.html (:prefix + :sources)
== LiveReload accepting connections from ws://192.168.0.23:35729
== View your site at "http://Ikuos-MacBook-Pro.local:4567", "http://192.168.0.23:4567"
== Inspect your site configuration at "http://Ikuos-MacBook-Pro.local:4567/__middleman", "http://192.168.0.23:4567/__middleman"
== External: > query_ok@1.0.0 watch /Users/ikuwow/ghq/github.com/ikuwow/query_ok
== External: > webpack --config webpack.dev.js --watch -d
error: option '-d, --devtool <value>' argument missing
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! query_ok@1.0.0 watch: `webpack --config webpack.dev.js --watch -d`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the query_ok@1.0.0 watch script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/ikuwow/.npm/_logs/2020-12-21T14_40_05_826Z-debug.log
== External: Command failed with non-zero exit status
```