### PR TITLE
Uninstall middleman-search_engine_sitemap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'middleman-favicon-maker'
 gem 'middleman-livereload'
 gem 'middleman-minify-html'
 gem 'middleman-s3_sync'
-gem 'middleman-search_engine_sitemap'
 gem 'middleman-syntax'
 
 gem 'font-awesome-middleman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,9 +122,6 @@ GEM
       parallel
       ruby-progressbar
       unf
-    middleman-search_engine_sitemap (1.4.0)
-      builder
-      middleman-core (~> 4.0)
     middleman-syntax (3.2.0)
       middleman-core (>= 3.2)
       rouge (~> 3.2)
@@ -182,7 +179,6 @@ DEPENDENCIES
   middleman-livereload
   middleman-minify-html
   middleman-s3_sync
-  middleman-search_engine_sitemap
   middleman-syntax
   mime-types
   nokogiri

--- a/config.rb
+++ b/config.rb
@@ -61,7 +61,6 @@ set :markdown,
     strikethrough: true
 
 set :url_root, $base_url
-activate :search_engine_sitemap
 
 activate :s3_sync do |s3_sync|
   s3_sync.region = 'ap-northeast-1'

--- a/source/sitemap.xml.builder
+++ b/source/sitemap.xml.builder
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 xml.instruct!
 xml.urlset 'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9' do
   sitemap.resources.select do |resource|

--- a/source/sitemap.xml.builder
+++ b/source/sitemap.xml.builder
@@ -1,0 +1,8 @@
+xml.instruct!
+xml.urlset 'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9' do
+  sitemap.resources.select do |resource|
+    xml.url do
+      xml.loc "#{@base_url}#{resource.url}"
+    end
+  end
+end

--- a/source/sitemap.xml.builder
+++ b/source/sitemap.xml.builder
@@ -2,9 +2,15 @@
 
 xml.instruct!
 xml.urlset 'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9' do
-  sitemap.resources.select do |resource|
+  pages = sitemap.resources.select do |resource|
+    resource.path.end_with?(File.extname(app.config.index_file))
+  end
+
+  pages.each do |page|
     xml.url do
-      xml.loc "#{@base_url}#{resource.url}"
+      xml.loc File.join(app.config.url_root, page.url)
+      xml.lastmod(File.mtime(page.source_file).iso8601) if page.source_file
+      xml.changefreq 'monthly'
     end
   end
 end


### PR DESCRIPTION
middleman-search_engine_sitemap is now unmaintained.
https://github.com/Aupajo/middleman-search_engine_sitemap

[sitemap_before.xml.txt](https://github.com/ikuwow/query_ok/files/5742745/sitemap_before.xml.txt)

```
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <url>
    <loc>https://queryok.ikuwow.com/tags/</loc>
    <lastmod>2020-12-21T18:02:31+00:00</lastmod>
    <changefreq>monthly</changefreq>
    <priority>0.5</priority>
  </url>
  <url>
[...]
```
