### PR TITLE
Unignore yushakobo twitter

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -82,7 +82,6 @@ activate :external_pipeline,
          latency: 1
 
 activate :twitter_oembed do |twitter|
-  twitter.convert_regex = %r{^https?://twitter.com/(?!yushakobo)[a-zA-Z0-9_]+/status/(\d+)$}
   twitter.omit_script = true
   twitter.use_cache   = false
 end


### PR DESCRIPTION
It has to be review-ready when [yushakobo](https://twitter.com/yushakobo) is unsuspended.

ref: https://github.com/atarukodaka/middleman-twitter-oembed/blob/1c5d8854f018425636221eb9b1e95aa712a3c95e/lib/middleman-twitter-oembed/extension.rb#L8