### PR TITLE
Specify haml version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'middleman-minify-html'
 gem 'middleman-syntax'
 gem 'middleman-twitter-oembed'
 
+gem 'haml', '< 6.0.0'
+
 gem 'redcarpet'
 
 # For feed.xml.builder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,10 +12,10 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.8.1)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
-    backports (3.23.0)
+    backports (3.24.1)
     better_html (1.0.16)
       actionview (>= 4.0)
       activesupport (>= 4.0)
@@ -32,11 +32,11 @@ GEM
     concurrent-ruby (1.2.2)
     contracts (0.13.0)
     crass (1.0.6)
-    docile (1.3.1)
+    docile (1.4.0)
     dotenv (2.8.1)
-    em-websocket (0.5.2)
+    em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
-      http_parser.rb (~> 0.6.0)
+      http_parser.rb (~> 0)
     erb_lint (0.1.3)
       activesupport
       better_html (~> 1.0.7)
@@ -50,11 +50,11 @@ GEM
     eventmachine (1.2.7)
     execjs (2.8.1)
     fast_blank (1.0.1)
-    fastimage (2.2.6)
+    fastimage (2.2.7)
     favicon_maker (1.3.1)
       docile (~> 1.1)
     ffi (1.15.5)
-    haml (5.2.1)
+    haml (5.2.2)
       temple (>= 0.8.0)
       tilt
     hamster (3.0.0)
@@ -62,11 +62,11 @@ GEM
     hashie (3.6.0)
     html_tokenizer (0.0.7)
     htmlcompressor (0.2.0)
-    http_parser.rb (0.6.0)
+    http_parser.rb (0.8.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
-    kramdown (2.3.1)
+    kramdown (2.4.0)
       rexml
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -140,9 +140,9 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
-    public_suffix (5.0.0)
+    public_suffix (5.0.1)
     racc (1.7.1)
-    rack (2.2.6.4)
+    rack (2.2.7)
     rack-livereload (0.3.17)
       rack
     rails-dom-testing (2.0.3)
@@ -176,8 +176,8 @@ GEM
       ffi (~> 1.9)
     servolux (0.13.0)
     smart_properties (1.17.0)
-    temple (0.8.2)
-    thor (1.1.0)
+    temple (0.10.2)
+    thor (1.2.2)
     thread_safe (0.3.6)
     tilt (2.0.11)
     tzinfo (1.2.11)
@@ -192,6 +192,7 @@ PLATFORMS
 DEPENDENCIES
   builder
   erb_lint
+  haml (< 6.0.0)
   middleman (= 4.3.10)
   middleman-blog
   middleman-favicon-maker


### PR DESCRIPTION
middleman-syntax doesn't work with haml6
https://github.com/middleman/middleman-syntax/issues/80

bundle updated.