### PR TITLE
Fix circleci cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,13 @@ executors:
       - image: cimg/ruby:2.7.6-node
     environment:
       BUNDLE_APP_CONFIG: ~/project/.bundle/
-      BUNDLE_CACHE_VERSION: v5
-      NPM_CACHE_VERSION: v4
 
 commands:
   bundle_install:
+    parameters:
+      bundle_cache_version:
+        type: string
+        default: v6
     steps:
       - run:
           name: Update bundler to latest
@@ -31,24 +33,28 @@ commands:
             bundle config set --local clean true
       - restore_cache:
           keys:
-            - bundler-{{ .Environment.BUNDLE_CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - bundler-{{ .Environment.BUNDLE_CACHE_VERSION }}-{{ .Branch }}
-            - bundler-{{ .Environment.BUNDLE_CACHE_VERSION }}-master
+            - bundler-<< parameters.bundle_cache_version >>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - bundler-<< parameters.bundle_cache_version >>-{{ .Branch }}
+            - bundler-<< parameters.bundle_cache_version >>-master
       - run: bundle install
       - save_cache:
-          key: bundler-{{ .Environment.BUNDLE_CACHE_VERSION }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: bundler-<< parameters.bundle_cache_version >>-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
   npm_install:
+    parameters:
+      npm_cache_version:
+        type: string
+        default: v4
     steps:
       - restore_cache:
           keys:
-            - npm-{{ .Environment.NPM_CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
-            - npm-{{ .Environment.NPM_CACHE_VERSION }}-{{ .Branch }}
-            - npm-{{ .Environment.NPM_CACHE_VERSION }}-master
+            - npm-<< parameters.npm_cache_version >>-{{ .Branch }}-{{ checksum "package-lock.json" }}
+            - npm-<< parameters.npm_cache_version >>-{{ .Branch }}
+            - npm-<< parameters.npm_cache_version >>-master
       - run: npm install
       - save_cache:
-          key: npm-{{ .Environment.NPM_CACHE_VERSION }}-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          key: npm-<< parameters.npm_cache_version >>-{{ .Branch }}-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,10 @@ jobs:
   build:
     executor:
       name: default
+    parameters:
+      article_cache_version:
+        type: string
+        default: v2
     steps:
       - checkout
       - attach_workspace:
@@ -100,8 +104,8 @@ jobs:
       - npm_install
       - restore_cache:
           keys:
-            - articles-v1-{{ .Branch }}-{{ .Revision }}
-            - articles-v1-{{ .Branch }}
+            - articles-<< parameters.article_cache_version >>-{{ .Branch }}-{{ .Revision }}
+            - articles-<< parameters.article_cache_version >>-{{ .Branch }}
       - run:
           name: Build static pages
           command: bundle exec middleman build
@@ -110,7 +114,7 @@ jobs:
           when: on_fail
           command: bundle exec middleman build --verbose
       - save_cache:
-          key: articles-v1-{{ .Branch }}-{{ .Revision }}
+          key: articles-<< parameters.article_cache_version >>-{{ .Branch }}-{{ .Revision }}
           paths:
             - build
       - persist_to_workspace:


### PR DESCRIPTION
Environment varaibles defined in config.yml is not recognized in cache key


```
The environment variable variableName (supports any environment variable [exported by CircleCI](https://circleci.com/docs/env-vars/) or added to a specific [Context](https://circleci.com/docs/contexts/), not any arbitrary environment variable).
```

https://circleci.com/docs/caching/?utm_source=google&utm_medium=sem&utm_campaign=sem-google-dg--japac-en-dsa-tROAS-auth-brand&utm_term=g_-_c__dsa_&utm_content=&gclid=Cj0KCQjw1rqkBhCTARIsAAHz7K3-9uNLyFM-_qrLJ42gcrg6WTO3UntKjD4-sPDuUZ94o7PVO5FCELUaAkvxEALw_wcB