### PR TITLE
fix: ESLint設定の改善（PR #772 レビューコメント対応）

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,14 +7,13 @@ export default [
       'vendor/**',
       'build/**',
       '.tmp/**',
-      'dist/**',
-      'webpack.*.js'
+      'dist/**'
     ]
   },
   js.configs.recommended,
   {
     languageOptions: {
-      ecmaVersion: 2015,
+      ecmaVersion: 2020,
       sourceType: 'module',
       globals: {
         // Browser globals
@@ -32,9 +31,6 @@ export default [
         __dirname: 'readonly',
         __filename: 'readonly',
         global: 'readonly',
-        module: 'readonly',
-        require: 'readonly',
-        exports: 'readonly',
         // ES6 globals
         Promise: 'readonly',
         Symbol: 'readonly',


### PR DESCRIPTION
## 概要

PR #772 のレビューコメントで指摘された点を修正しました。

## 変更内容

### 修正した点 ✅

1. **webpack設定ファイルをESLintの対象に含める**
   - `eslint.config.js`のignores配列から`'webpack.*.js'`を削除
   - 本番用設定ファイルなので、コード品質基準に従うべきとの指摘に対応

2. **CommonJS globalsの削除**
   - ES Modules化に伴い、不要になったCommonJS用のglobalsを削除
   - 削除したglobals: `module`, `require`, `exports`

3. **ecmaVersionの更新**
   - 2015 → 2020に更新
   - webpack設定ファイルのimport構文をサポートするため

## 動作確認

- [x] ESLint実行: `npm run eslint` → エラーなし
- [x] ビルド実行: `npm run build` → 成功
- [x] CI通過: build & lint 両方成功

## 参考

- 元のPR: #772
- 対応したレビューコメント:
  - webpack設定ファイルのignore除外の提案
  - CommonJS globalsの削除提案

## 注意

最新のmasterから作成したブランチなので、既にマージされたPR #772のコミットは含まれていません。今回の修正のみが差分として表示されます。

## Review Ready

CIが全て通ったため、Review Readyにしました。