### PR TITLE
chore: Migrate from Dependabot reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code Owners for this repository
+# These owners will be the default owners for everything in the repo
+
+* @ikuwow

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     interval: monthly
     time: "20:00"
   open-pull-requests-limit: 10
-  reviewers:
-  - ikuwow
   assignees:
   - ikuwow
 - package-ecosystem: npm


### PR DESCRIPTION
## 概要
Dependabotのreviewersフィールドが廃止されるため、代わりにCODEOWNERSファイルを使用するように移行します。

## 変更内容
- `.github/dependabot.yml`からreviewersフィールドを削除
- `.github/CODEOWNERS`ファイルを作成し、`@ikuwow`をデフォルトのレビュアーに設定

## 背景
Dependabotからの通知により、`dependabot.yml`の`reviewers`フィールドが近々削除されることが判明したため対応。

Refs: #776

🤖 Generated with [Claude Code](https://claude.ai/code)