### PR TITLE
Drop double minify via Uglifier in Middleman build

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'uglifier'
-
 Time.zone = 'Tokyo'
 
 set :url_root, 'https://queryok.ikuwow.com'
@@ -36,9 +34,6 @@ ignore '/**/.*.swp'
 
 configure :build do
   activate :minify_css
-  activate :minify_javascript, compressor: lambda {
-    Uglifier.new(harmony: true)
-  }
   activate :minify_html
 
   activate :asset_hash


### PR DESCRIPTION
## Why

The webpack bump PR #920 (5.107.2 → 5.108.3) started failing the CircleCI `build` job with `Unexpected token: punc (.)` on `build/bundle-critical-*.js`. The stack trace points at `uglifier-4.2.1/lib/uglifier.rb:166 #compile`, invoked from `activate :minify_javascript, compressor: -> { Uglifier.new(harmony: true) }` in `config.rb`.

Root cause is a double minify path, not the bump itself:

- Webpack production mode already minifies the emitted bundles with Terser.
- Middleman then re-minifies the same output through the `uglifier` gem, whose bundled UglifyJS only understands ES5-ish syntax.
- Webpack 5.108.x now ships modern JS (e.g. optional chaining) in its runtime code, which UglifyJS cannot parse.

The `uglifier` gem has also gone quiet — [4.2.1 shipped on 2024-09-22](https://rubygems.org/gems/uglifier/versions/4.2.1) after a ~5-year gap from 4.2.0 (2019-09-25), so keeping the pass alive as a Ruby-side minifier is not a good long-term bet either.

## What

Remove the Middleman-side JS minify pass. The webpack production build (`webpack --config webpack.prod.js`, `mode: 'production'`) keeps handling minification for the bundles that actually ship.

The `uglifier` gem is only a transitive dependency in `Gemfile.lock`, so no Gemfile change is needed. It will drop out on the next `bundle update` naturally.

## Verification

- [x] Local `npm run build` on this branch produces minified `.tmp/dist/bundle-critical.js` and `.tmp/dist/bundle-main.js` (IIFE, single-char idents, no whitespace) and both pass `node --check`.
- [x] Compared to the currently deployed live bundles (double-minify): the Terser-only output is smaller uncompressed and gzip-neutral, so removing the Uglifier pass does not regress ship size.

Size comparison (bytes):

| bundle | live (Terser+Uglifier) | this branch (Terser only) | delta | delta (gzip) |
|---|---:|---:|---:|---:|
| `bundle-critical.js` | 141,451 | 133,753 | −7,698 | +255 |
| `bundle-main.js` | 4,425 | 4,416 | −9 | −25 |

## Follow-up

- Rebase / re-run dependabot PR #920 (webpack 5.108.3) — expected to pass once this lands
