### PR TITLE
Drop HTML minification from the build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem 'middleman', '~> 4.6.3'
 gem 'middleman-blog'
 gem 'middleman-favicon-maker'
 gem 'middleman-livereload'
-gem 'middleman-minify-html'
 gem 'middleman-syntax'
 
 gem 'ruby-oembed'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,6 @@ GEM
       concurrent-ruby (~> 1.0)
     hashie (5.1.0)
       logger
-    htmlcompressor (0.2.0)
     http_parser.rb (0.8.0)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
@@ -132,9 +131,6 @@ GEM
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
       rack-livereload (~> 0.6.1)
-    middleman-minify-html (3.4.1)
-      htmlcompressor (~> 0.2.0)
-      middleman-core (>= 3.2)
     middleman-syntax (3.6.1)
       middleman-core (>= 3.2)
       rouge (~> 3.2)
@@ -224,7 +220,6 @@ DEPENDENCIES
   middleman-blog
   middleman-favicon-maker
   middleman-livereload
-  middleman-minify-html
   middleman-syntax
   redcarpet
   rubocop

--- a/config.rb
+++ b/config.rb
@@ -34,7 +34,6 @@ ignore '/**/.*.swp'
 
 configure :build do
   activate :minify_css
-  activate :minify_html
 
   activate :asset_hash
 


### PR DESCRIPTION
Part of #926.

Removes `middleman-minify-html`. HTML ships unminified; compression stays at the CDN layer, and `minify_css` is untouched.

## Why

- [`middleman/middleman-minify-html`](https://github.com/middleman/middleman-minify-html/commits/master): no commits since 2020-08-16
- It pins `htmlcompressor` to `~> 0.2.0`. That gem's own latest release is [0.4.0, from 2017-12](https://rubygems.org/gems/htmlcompressor/versions), so the pin sits two minor versions behind an already-dormant dependency

## Size cost, measured

Both builds run locally from the same source tree (ruby 3.4.6, node 22.19.0), 130 HTML files each.

| | with minify | without | delta |
|---|---|---|---|
| raw | 1,391,199 B | 1,594,854 B | +203,655 B (+14.6%) |
| gzip -9 | 481,325 B | 514,164 B | +32,839 B (+6.8%) |

The gzip row is the delivered figure: **+253 B per page over the wire**. CloudFront serves gzip on every HTML path sampled — 6 paths x 5 GETs plus HEAD requests, all returning `content-encoding: gzip`, and the payloads really are compressed (`/about/` 4796 -> 1501 B, `/entry/i2cssh/` 9456 -> 3394 B).

Brotli is not served: `Accept-Encoding: br` alone returns the response uncompressed on every attempt. Had it been enabled, the same corpus compresses to 388,254 B vs 408,079 B at `brotli -q11`, so +152 B per page. Enabling it on the distribution is a separate change and is not assumed here.

CloudFront's gzip level is lower than `gzip -9` (3394 B vs 3321 B on `/entry/i2cssh/`), so the table slightly understates both columns without changing the delta's direction.

Rendering is unaffected: the compressor's visible work here was collapsing whitespace runs to a single space, stripping comments, and dropping unnecessary attribute quotes. A newline and a single space both collapse to one space in the browser, including between CJK characters, so Japanese text lays out identically — confirmed by diffing a built article page, where the minified output already carried the space (`csshXというツールがある。 複数のホストに`).

## Verification

`diff -rq` between a baseline build of `master` and this branch: every difference is an HTML file. All CSS, JS, and image output is byte-identical, so no `asset_hash` digest changes and no cache churn on assets.

The baseline build matches what is live: `/entry/i2cssh/` serves 9456 uncompressed bytes, exactly the size of that page in the local minified build.

Two entries in the `diff -rq` output are unrelated to this change: a stray `.DS_Store` in the main checkout, and `sitemap.xml`, whose `lastmod` comes from `File.mtime(page.source_file)` and so tracks checkout time in a fresh worktree.

## Alternatives considered

- Keep minifying via a local extension calling `htmlcompressor` directly — about 25 lines, the same shape as `extensions/oembed_converter.rb`, but it keeps the same 2016-era compressor and only removes a wrapper
- Swap in `minify_html`, the Ruby binding for the Rust `wilsonzlin/minify-html`. Upstream is active and [0.18.1 is on rubygems](https://rubygems.org/gems/minify_html/versions) as of 2025-10, but only as precompiled platform gems; the last plain-`ruby` build is 0.11.2 from 2023-12. This repo's `.bundle/config` sets `BUNDLE_FORCE_RUBY_PLATFORM: true`, which per bundler's man page makes it "install only `ruby` platform gems", so adoption would mean revisiting that setting and adding platforms to `Gemfile.lock`
- Hand-write the compressor. Rejected: whitespace collapsing has to protect `<pre>`, `<code>`, `<textarea>`, `<script>`, and `<style>`, and this site is full of `<pre>` blocks from middleman-syntax

## Note on merge order

This branch and #947 both edit `Gemfile`, `Gemfile.lock`, and the `configure :build` block in `config.rb`. Whichever merges second needs `gh pr update-branch` and a `bundle install` to re-resolve the lockfile.
