### PR TITLE
Make README pass markdownlint

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -6,6 +6,9 @@
   // line-length
   "MD013": false,
 
+  // no-trailing-punctuation: the blog's name is "Query OK.", period included
+  "MD026": { "punctuation": ",;:!。，；：！" },
+
   // no-inline-html
   "MD033": false,
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-Query OK.
+# Query OK.
+
 [![CircleCI](https://circleci.com/gh/ikuwow/query_ok.svg?style=svg)](https://circleci.com/gh/ikuwow/query_ok)
-===========================
 
 ikuwow's blog.
 
@@ -14,14 +14,14 @@ ikuwow's blog.
 
 Install dependencies:
 
-```
+```bash
 bundle install
 npm install
 ```
 
 Start the dev server:
 
-```
+```bash
 bundle exec middleman server
 ```
 
@@ -29,7 +29,7 @@ The site runs at http://localhost:4567/. Frontend assets are built and watched a
 
 ## Writing an article
 
-```
+```bash
 ./article.sh <title>
 ```
 
@@ -37,7 +37,7 @@ This creates a branch, generates the article scaffold, commits and pushes it.
 
 ## How to Deploy
 
-```
+```bash
 aws s3 sync --delete build s3://queryok.ikuwow.com/
 ```
 


### PR DESCRIPTION
## Summary

`README.md` failed `markdownlint-cli2` on 9 rules, which blocked the `pre-commit` hook for any commit touching the file. This makes it pass.

The gap exists because the two linting paths cover different files: the `markdownlint-cli2` hook in `.pre-commit-config.yaml` lints every Markdown file in the repository, while the `npm run markdownlint` script used by CI only globs `source/**/*.md`. README violations were therefore never surfaced by CI.

## Changes

- `MD003/heading-style`: the title switches from setext to atx so it matches the `##` headings used throughout the rest of the file
- `MD040/fenced-code-language`: the four fenced code blocks get a `bash` language tag, matching the convention already used in `CLAUDE.md`
- `MD026/no-trailing-punctuation`: `.markdownlint.jsonc` drops `.` from the punctuation set, because the blog's name is "Query OK." and the period belongs in the title

No prose or command content changes.

## Verification

- `npx markdownlint-cli2 "**/*.md" "!node_modules"` → `Summary: 0 issues in 0 files` across 83 files, so relaxing MD026 introduces no regression in `source/posts/`
- The `pre-commit` hook (`markdownlint-cli2` v0.8.1, pinned in `.pre-commit-config.yaml`) passes on this commit
